### PR TITLE
LPS-53122 Rename table in accordance with 6.2

### DIFF
--- a/portlets/notifications-portlet/docroot/WEB-INF/src/com/liferay/notifications/hook/upgrade/v2_0_0/UpgradeUserNotificationEvent.java
+++ b/portlets/notifications-portlet/docroot/WEB-INF/src/com/liferay/notifications/hook/upgrade/v2_0_0/UpgradeUserNotificationEvent.java
@@ -33,7 +33,7 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 	}
 
 	protected void upgradeNotifications() throws Exception {
-		if (!hasTable("Notifications_UserNotificationEvent")) {
+		if (!hasTable("Notifications_UserEvent")) {
 			return;
 		}
 
@@ -46,7 +46,7 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 
 			ps = con.prepareStatement(
 				"select userNotificationEventId, actionRequired from " +
-					"Notifications_UserNotificationEvent");
+					"Notifications_UserEvent");
 
 			rs = ps.executeQuery();
 
@@ -69,7 +69,7 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 			DataAccess.cleanUp(con, ps, rs);
 		}
 
-		runSQL("drop table Notifications_UserNotificationEvent");
+		runSQL("drop table Notifications_UserEvent");
 	}
 
 }


### PR DESCRIPTION
Hey Jon,

Here is the pull that you wanted for Master. It's very different from the 6.2 fix because we're creating the table in 6.2 but then in Master, we're just reading from that table and then dropping it. If the fix for 6.2 gets source formatted and the table name is changed, this fix will also need to be changed.

Thanks.